### PR TITLE
Use v2 config and sse endpoints

### DIFF
--- a/lib/reforge/config_client.rb
+++ b/lib/reforge/config_client.rb
@@ -129,7 +129,7 @@ module Reforge
 
     def load_source_checkpoint(start_at_id: 0)
       @options.config_sources.each do |source|
-        conn = Reforge::CachingHttpConnection.new("#{source}/api/v1/configs/#{start_at_id}", @base_client.sdk_key)
+        conn = Reforge::CachingHttpConnection.new("#{source}/api/v2/configs/#{start_at_id}", @base_client.sdk_key)
         result = load_url(conn, :remote_api)
         return true if result
       end

--- a/lib/reforge/sse_config_client.rb
+++ b/lib/reforge/sse_config_client.rb
@@ -64,7 +64,7 @@ module Reforge
     end
 
     def connect(&load_configs)
-      url = "#{source}/api/v1/sse/config"
+      url = "#{source}/api/v2/sse/config"
       @logger.debug "SSE Streaming Connect to #{url} start_at #{@config_loader.highwater_mark}"
 
       SSE::Client.new(url,

--- a/test/test_sse_config_client.rb
+++ b/test/test_sse_config_client.rb
@@ -154,7 +154,7 @@ class TestSSEConfigClient < Minitest::Test
     log_string = StringIO.new
     logger = WEBrick::Log.new(log_string)
     server = WEBrick::HTTPServer.new(Port: port, Logger: logger, AccessLog: [])
-    server.mount '/api/v1/sse/config', endpoint_class
+    server.mount '/api/v2/sse/config', endpoint_class
 
     [server, log_string]
   end


### PR DESCRIPTION
## Description
Switch to v2 config and sse endpoints -- mostly so we'll know old prefab clients are hitting v1