### PR TITLE
Fix automated gem publishing workflow

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -31,5 +31,3 @@ jobs:
 
       - name: Release gem
         uses: rubygems/release-gem@v1
-        with:
-          gem-name: reforge

--- a/Rakefile
+++ b/Rakefile
@@ -48,8 +48,16 @@ unless ENV['CI']
     version = File.exist?('VERSION') ? File.read('VERSION') : ''
 
     rdoc.rdoc_dir = 'rdoc'
-    rdoc.title = "prefab-cloud-ruby #{version}"
+    rdoc.title = "sdk-reforge #{version}"
     rdoc.rdoc_files.include('README*')
     rdoc.rdoc_files.include('lib/**/*.rb')
   end
+end
+
+# Add release task for CI
+task :release do
+  sh 'gem build sdk-reforge.gemspec'
+  version = File.read('VERSION').strip
+  gem_file = "sdk-reforge-#{version}.gem"
+  sh "gem push #{gem_file}"
 end


### PR DESCRIPTION
## Summary

- Remove invalid `gem-name` parameter from `rubygems/release-gem@v1` action
- Add custom `rake release` task that works in CI environment
- Fix RDoc title to use correct gem name `sdk-reforge`
- This fixes the workflow errors from previous PR #10

## Changes

- **Workflow**: Remove unsupported `gem-name` parameter 
- **Rakefile**: Add `rake release` task that builds and pushes gem
- **Rakefile**: Fix RDoc title to match new gem name

## Test plan

- [x] YAML validation passes
- [x] `rake release` task exists and is available
- [ ] Test workflow runs successfully after Ruby tests complete
- [ ] Verify gem publishes correctly to RubyGems

This supersedes PR #10 and fixes the workflow issues.

🤖 Generated with [Claude Code](https://claude.ai/code)