### PR TITLE
Fix gem build to use standard pkg directory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,8 +56,9 @@ end
 
 # Add release task for CI
 task :release do
-  sh 'gem build sdk-reforge.gemspec'
+  sh 'mkdir -p pkg'
+  sh 'gem build sdk-reforge.gemspec --output pkg/'
   version = File.read('VERSION').strip
-  gem_file = "sdk-reforge-#{version}.gem"
+  gem_file = "pkg/sdk-reforge-#{version}.gem"
   sh "gem push #{gem_file}"
 end


### PR DESCRIPTION
## Summary

Fix the gem build process to use the standard `pkg/` directory, which resolves the `rubygems-await` error from the previous workflow runs.

## Changes

- **Rakefile**: Update `rake release` task to build gems in `pkg/` directory using `--output pkg/` flag
- **Workflow**: Remove `await-release: false` parameter to re-enable gem propagation verification

## Why this fix?

The `rubygems/release-gem@v1` action runs `gem exec rubygems-await pkg/*.gem` to wait for the gem to be available on RubyGems. Our previous build was putting the gem file in the root directory, causing the error:

```
No such file or directory @ rb_sysopen - pkg/*.gem
```

## Benefits

- ✅ Follows Ruby gem packaging conventions
- ✅ Fixes the workflow error we saw in the previous run  
- ✅ Allows `await-release` to work properly (waits for gem propagation)
- ✅ Gem was successfully published as `sdk-reforge 1.9.0` in the previous run

🤖 Generated with [Claude Code](https://claude.ai/code)