### PR TITLE
Fix gem build and add version check for publishing

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -29,5 +29,18 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
 
+      - name: Check if version already exists
+        id: version-check
+        run: |
+          VERSION=$(cat VERSION)
+          if gem list -r sdk-reforge | grep -q "sdk-reforge ($VERSION)"; then
+            echo "version-exists=true" >> $GITHUB_OUTPUT
+            echo "Version $VERSION already exists on RubyGems, skipping publish"
+          else
+            echo "version-exists=false" >> $GITHUB_OUTPUT
+            echo "Version $VERSION not found, proceeding with publish"
+          fi
+
       - name: Release gem
+        if: steps.version-check.outputs.version-exists == 'false'
         uses: rubygems/release-gem@v1

--- a/Rakefile
+++ b/Rakefile
@@ -57,8 +57,8 @@ end
 # Add release task for CI
 task :release do
   sh 'mkdir -p pkg'
-  sh 'gem build sdk-reforge.gemspec --output pkg/'
   version = File.read('VERSION').strip
   gem_file = "pkg/sdk-reforge-#{version}.gem"
+  sh "gem build sdk-reforge.gemspec --output #{gem_file}"
   sh "gem push #{gem_file}"
 end


### PR DESCRIPTION
## Summary

Fixes two critical issues with the automated gem publishing workflow:

1. **Gem build error**: The `--output pkg/` was treating `pkg/` as a file instead of a directory
2. **Duplicate publishing**: Added version check to prevent republishing existing versions

## Changes

### Rakefile
- Fix gem build to specify full file path: `--output pkg/sdk-reforge-#{version}.gem`
- Reorder commands to read version first, then use in gem_file variable

### Workflow (.github/workflows/push_gem.yml)
- Add version check step that queries RubyGems for existing versions
- Only run gem publishing if version doesn't already exist
- Includes helpful logging to show what's happening

## Fixes

- ❌ **Before**: `gem build sdk-reforge.gemspec --output pkg/` → "Is a directory" error
- ✅ **After**: `gem build sdk-reforge.gemspec --output pkg/sdk-reforge-1.9.0.gem` → works correctly

- ❌ **Before**: Always tries to publish, causing "repushing not allowed" errors
- ✅ **After**: Checks if version exists first, skips if already published

## Test Results Expected

- First run with new version: publishes successfully
- Subsequent runs with same version: skips publishing with message "Version X.X.X already exists on RubyGems, skipping publish"

🤖 Generated with [Claude Code](https://claude.ai/code)